### PR TITLE
Fixed trailing comma error during installation for Sublime Text 2.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -83,7 +83,7 @@
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – User"
-                            },
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
Error trying to parse file: Trailing comma before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/escape & unescape tool/Main.sublime-menu:87:25
